### PR TITLE
[WIP] added missing 'partition' argument to slurm launcher

### DIFF
--- a/R/crew_controller_slurm.R
+++ b/R/crew_controller_slurm.R
@@ -53,7 +53,8 @@ crew_controller_slurm <- function(
   slurm_log_error = "/dev/null",
   slurm_memory_gigabytes_per_cpu = NULL,
   slurm_cpus_per_task = NULL,
-  slurm_time_minutes = 1440
+  slurm_time_minutes = 1440,
+  slurm_partition = NULL
 ) {
   if (!is.null(seconds_exit)) {
     crew::crew_deprecate(
@@ -96,7 +97,8 @@ crew_controller_slurm <- function(
     slurm_log_error = slurm_log_error,
     slurm_memory_gigabytes_per_cpu = slurm_memory_gigabytes_per_cpu,
     slurm_cpus_per_task = slurm_cpus_per_task,
-    slurm_time_minutes = slurm_time_minutes
+    slurm_time_minutes = slurm_time_minutes,
+    slurm_partition = slurm_partition
   )
   controller <- crew::crew_controller(client = client, launcher = launcher)
   controller$validate()


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew.cluster/blob/main/CODE_OF_CONDUCT.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/crew.cluster/discussions) or [issue](https://github.com/ropensci/crew.cluster/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #24 

# Summary

Make the slurm partition configurable for `crew_controller_slurm()`
