### PR TITLE
Support job arrays

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: github::wlandau/crew, any::rcmdcheck, local::.
+          extra-packages: any::rcmdcheck, local::., github::wlandau/crew
           needs: check
           cache-version: 3
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, local::., github::wlandau/crew
+          extra-packages: any::rcmdcheck, local::., github::wlandau/crew, github::r-lib/mirai, github::r-lib/nanonext
           needs: check
           cache-version: 3
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, local::.
+          extra-packages: github::wlandau/crew, any::rcmdcheck, local::.
           needs: check
           cache-version: 3
 

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, github::wlandau/crew
           needs: coverage
           cache-version: 3
 

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2, github::wlandau/crew
+          extra-packages: any::covr, any::xml2, github::wlandau/crew, github::r-lib/mirai, github::r-lib/nanonext
           needs: coverage
           cache-version: 3
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::., github::wlandau/crew
           needs: website
           cache-version: 3
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::., github::wlandau/crew
+          extra-packages: any::pkgdown, local::., github::wlandau/crew, github::r-lib/mirai, github::r-lib/nanonext
           needs: website
           cache-version: 3
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: In computationally demanding analysis projects,
   'clustermq' by Schubert (2019) <doi:10.1093/bioinformatics/btz284>),
   and 'batchtools' by Lang, Bischl, and Surmann (2017).
   <doi:10.21105/joss.00135>.
-Version: 0.3.8.9001
+Version: 0.3.8.9002
 License: MIT + file LICENSE
 URL: https://wlandau.github.io/crew.cluster/,
   https://github.com/wlandau/crew.cluster
@@ -49,7 +49,7 @@ Authors@R: c(
 Depends:
   R (>= 4.0.0)
 Imports:
-  crew (>= 1.2.0),
+  crew (>= 1.2.1.9009),
   ps,
   lifecycle,
   R6,
@@ -63,6 +63,8 @@ Suggests:
   markdown (>= 1.1),
   rmarkdown (>= 2.4),
   testthat (>= 3.0.0)
+Remotes:
+  wlandau/crew
 Encoding: UTF-8
 Language: en-US
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,8 +63,6 @@ Suggests:
   markdown (>= 1.1),
   rmarkdown (>= 2.4),
   testthat (>= 3.0.0)
-Remotes:
-  wlandau/crew
 Encoding: UTF-8
 Language: en-US
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# crew.cluster 0.3.8.9001 (development)
+# crew.cluster 0.3.8.9002 (development)
 
 * Remove `termiante_worker()` and deprecate `command_terminate` (https://github.com/wlandau/crew/pull/236).
 * Only use `call` and `name` in `launch_worker()`.
+* Support job arrays (#56, #57).
 
 # crew.cluster 0.3.8
 

--- a/R/crew_launcher_cluster.R
+++ b/R/crew_launcher_cluster.R
@@ -192,8 +192,7 @@ crew_class_launcher_cluster <- R6::R6Class(
       crew_options_validate(private$.options_cluster)
       invisible()
     },
-    #' @description Launch a local process worker which will
-    #'   dial into a socket.
+    #' @description Launch a job array
     #' @details The `call` argument is R code that will run to
     #'   initiate the worker.
     #' @return A handle object to allow the termination of the worker
@@ -201,19 +200,17 @@ crew_class_launcher_cluster <- R6::R6Class(
     #' @param call Character string, a namespaced call to
     #'   [crew::crew_worker()]
     #'   which will run in the worker and accept tasks.
-    #' @param name Character string, an informative worker name.
-    #' @param launcher Deprecated in `crew.cluster`.
-    #' @param worker Deprecated in `crew.cluster`.
-    #' @param instance Deprecated in `crew.cluster`.
-    launch_worker = function(
-      call,
-      name,
-      launcher = NULL,
-      worker = NULL,
-      instance = NULL
-    ) {
+    #' @param n Positive integer of length 1, number of workers to launch
+    #'   in the current round of auto-scaling.
+    launch_workers = function(call, n) {
+      name <- paste0(
+        "crew-worker-",
+        self$name,
+        "-",
+        nanonext::random(n = 4L)
+      )
       lines <- c(
-        self$script(name = name),
+        self$script(name = name, n = n),
         paste("Rscript -e", shQuote(call))
       )
       if (!file.exists(private$.options_cluster$script_directory)) {

--- a/R/crew_launcher_lsf.R
+++ b/R/crew_launcher_lsf.R
@@ -162,6 +162,9 @@ crew_class_launcher_lsf <- R6::R6Class(
     #' @return Character vector of the lines of the job script.
     #' @param name Character of length 1, name of the job. For inspection
     #'   purposes, you can supply a mock job name.
+    #' @param n Positive integer of length 1, number of crew workers
+    #'   (i.e. cluster jobs) to launch in the current round
+    #'   of auto-scaling.
     #' @examples
     #' if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
     #' launcher <- crew_launcher_lsf(
@@ -172,11 +175,11 @@ crew_class_launcher_lsf <- R6::R6Class(
     #' )
     #' launcher$script(name = "my_job_name")
     #' }
-    script = function(name) {
+    script = function(name, n) {
       options <- private$.options_cluster
       c(
         "#!/bin/sh",
-        paste("#BSUB -J", name),
+        sprintf("#BSUB -J \"%s[1-%s]\"", name, n),
         if_any(
           is.null(options$cwd),
           character(0L),

--- a/R/crew_launcher_pbs.R
+++ b/R/crew_launcher_pbs.R
@@ -159,6 +159,9 @@ crew_class_launcher_pbs <- R6::R6Class(
     #' @return Character vector of the lines of the job script.
     #' @param name Character of length 1, name of the job. For inspection
     #'   purposes, you can supply a mock job name.
+    #' @param n Positive integer of length 1, number of crew workers
+    #'   (i.e. cluster jobs) to launch in the current round
+    #'   of auto-scaling.
     #' @examples
     #' if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
     #' launcher <- crew_launcher_pbs(
@@ -167,10 +170,11 @@ crew_class_launcher_pbs <- R6::R6Class(
     #' )
     #' launcher$script(name = "my_job_name")
     #' }
-    script = function(name) {
+    script = function(name, n) {
       options <- private$.options_cluster
       c(
         paste("#PBS -N", name),
+        paste0("#PBS -J 1-", n),
         paste("#PBS -o", options$log_output),
         if_any(
           is.null(options$log_error),

--- a/R/crew_launcher_sge.R
+++ b/R/crew_launcher_sge.R
@@ -162,6 +162,9 @@ crew_class_launcher_sge <- R6::R6Class(
     #' @return Character vector of the lines of the job script.
     #' @param name Character of length 1, name of the job. For inspection
     #'   purposes, you can supply a mock job name.
+    #' @param n Positive integer of length 1, number of crew workers
+    #'   (i.e. cluster jobs) to launch in the current round
+    #'   of auto-scaling.
     #' @examples
     #' if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
     #' launcher <- crew_launcher_sge(
@@ -170,10 +173,11 @@ crew_class_launcher_sge <- R6::R6Class(
     #' )
     #' launcher$script(name = "my_job_name")
     #' }
-    script = function(name) {
+    script = function(name, n) {
       options <- private$.options_cluster
       c(
         paste("#$ -N", name),
+        paste0("#$ -t 1-", n),
         if_any(options$cwd, "#$ -cwd", character(0L)),
         if_any(options$envvars, "#$ -V", character(0L)),
         paste("#$ -o", options$log_output),

--- a/R/crew_launcher_slurm.R
+++ b/R/crew_launcher_slurm.R
@@ -156,6 +156,9 @@ crew_class_launcher_slurm <- R6::R6Class(
     #' @return Character vector of the lines of the job script.
     #' @param name Character of length 1, name of the job. For inspection
     #'   purposes, you can supply a mock job name.
+    #' @param n Positive integer of length 1, number of crew workers
+    #'   (i.e. cluster jobs) to launch in the current round
+    #'   of auto-scaling.
     #' @examples
     #' if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
     #' launcher <- crew_launcher_slurm(
@@ -165,11 +168,12 @@ crew_class_launcher_slurm <- R6::R6Class(
     #' )
     #' launcher$script(name = "my_job_name")
     #' }
-    script = function(name) {
+    script = function(name, n) {
       options <- private$.options_cluster
       c(
         "#!/bin/sh",
         paste0("#SBATCH --job-name=", name),
+        paste0("#SBATCH --array=1-", n),
         if_any(
           is.null(options$log_output),
           character(0L),

--- a/man/crew_class_launcher_cluster.Rd
+++ b/man/crew_class_launcher_cluster.Rd
@@ -45,7 +45,7 @@ Other cluster:
 \itemize{
 \item \href{#method-crew_class_launcher_cluster-new}{\code{crew_class_launcher_cluster$new()}}
 \item \href{#method-crew_class_launcher_cluster-validate}{\code{crew_class_launcher_cluster$validate()}}
-\item \href{#method-crew_class_launcher_cluster-launch_worker}{\code{crew_class_launcher_cluster$launch_worker()}}
+\item \href{#method-crew_class_launcher_cluster-launch_workers}{\code{crew_class_launcher_cluster$launch_workers()}}
 }
 }
 \if{html}{\out{
@@ -54,15 +54,14 @@ Other cluster:
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="call"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-call'><code>crew::crew_class_launcher$call()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="crashes"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-crashes'><code>crew::crew_class_launcher$crashes()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch'><code>crew::crew_class_launcher$launch()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch_worker"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch_worker'><code>crew::crew_class_launcher$launch_worker()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="poll"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-poll'><code>crew::crew_class_launcher$poll()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="resolve"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-resolve'><code>crew::crew_class_launcher$resolve()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="scale"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-scale'><code>crew::crew_class_launcher$scale()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="set_name"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-set_name'><code>crew::crew_class_launcher$set_name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="settings"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-settings'><code>crew::crew_class_launcher$settings()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="start"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-start'><code>crew::crew_class_launcher$start()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate'><code>crew::crew_class_launcher$terminate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate_workers"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate_workers'><code>crew::crew_class_launcher$terminate_workers()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="update"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-update'><code>crew::crew_class_launcher$update()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -150,19 +149,12 @@ Validate the launcher.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-crew_class_launcher_cluster-launch_worker"></a>}}
-\if{latex}{\out{\hypertarget{method-crew_class_launcher_cluster-launch_worker}{}}}
-\subsection{Method \code{launch_worker()}}{
-Launch a local process worker which will
-dial into a socket.
+\if{html}{\out{<a id="method-crew_class_launcher_cluster-launch_workers"></a>}}
+\if{latex}{\out{\hypertarget{method-crew_class_launcher_cluster-launch_workers}{}}}
+\subsection{Method \code{launch_workers()}}{
+Launch a job array
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_cluster$launch_worker(
-  call,
-  name,
-  launcher = NULL,
-  worker = NULL,
-  instance = NULL
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_cluster$launch_workers(call, n)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -172,13 +164,8 @@ dial into a socket.
 \code{\link[crew:crew_worker]{crew::crew_worker()}}
 which will run in the worker and accept tasks.}
 
-\item{\code{name}}{Character string, an informative worker name.}
-
-\item{\code{launcher}}{Deprecated in \code{crew.cluster}.}
-
-\item{\code{worker}}{Deprecated in \code{crew.cluster}.}
-
-\item{\code{instance}}{Deprecated in \code{crew.cluster}.}
+\item{\code{n}}{Positive integer of length 1, number of workers to launch
+in the current round of auto-scaling.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/crew_class_launcher_lsf.Rd
+++ b/man/crew_class_launcher_lsf.Rd
@@ -60,17 +60,16 @@ Other lsf:
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="call"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-call'><code>crew::crew_class_launcher$call()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="crashes"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-crashes'><code>crew::crew_class_launcher$crashes()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch'><code>crew::crew_class_launcher$launch()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch_worker"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch_worker'><code>crew::crew_class_launcher$launch_worker()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="poll"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-poll'><code>crew::crew_class_launcher$poll()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="resolve"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-resolve'><code>crew::crew_class_launcher$resolve()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="scale"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-scale'><code>crew::crew_class_launcher$scale()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="set_name"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-set_name'><code>crew::crew_class_launcher$set_name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="settings"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-settings'><code>crew::crew_class_launcher$settings()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="start"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-start'><code>crew::crew_class_launcher$start()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate'><code>crew::crew_class_launcher$terminate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate_workers"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate_workers'><code>crew::crew_class_launcher$terminate_workers()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="update"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-update'><code>crew::crew_class_launcher$update()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="initialize"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-initialize'><code>crew.cluster::crew_class_launcher_cluster$initialize()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_worker"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_worker'><code>crew.cluster::crew_class_launcher_cluster$launch_worker()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_workers"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_workers'><code>crew.cluster::crew_class_launcher_cluster$launch_workers()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -93,7 +92,7 @@ Validate the launcher.
 \subsection{Method \code{script()}}{
 Generate the job script.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_lsf$script(name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_lsf$script(name, n)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -101,6 +100,10 @@ Generate the job script.
 \describe{
 \item{\code{name}}{Character of length 1, name of the job. For inspection
 purposes, you can supply a mock job name.}
+
+\item{\code{n}}{Positive integer of length 1, number of crew workers
+(i.e. cluster jobs) to launch in the current round
+of auto-scaling.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/crew_class_launcher_pbs.Rd
+++ b/man/crew_class_launcher_pbs.Rd
@@ -58,17 +58,16 @@ Other pbs:
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="call"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-call'><code>crew::crew_class_launcher$call()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="crashes"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-crashes'><code>crew::crew_class_launcher$crashes()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch'><code>crew::crew_class_launcher$launch()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch_worker"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch_worker'><code>crew::crew_class_launcher$launch_worker()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="poll"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-poll'><code>crew::crew_class_launcher$poll()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="resolve"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-resolve'><code>crew::crew_class_launcher$resolve()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="scale"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-scale'><code>crew::crew_class_launcher$scale()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="set_name"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-set_name'><code>crew::crew_class_launcher$set_name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="settings"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-settings'><code>crew::crew_class_launcher$settings()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="start"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-start'><code>crew::crew_class_launcher$start()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate'><code>crew::crew_class_launcher$terminate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate_workers"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate_workers'><code>crew::crew_class_launcher$terminate_workers()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="update"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-update'><code>crew::crew_class_launcher$update()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="initialize"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-initialize'><code>crew.cluster::crew_class_launcher_cluster$initialize()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_worker"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_worker'><code>crew.cluster::crew_class_launcher_cluster$launch_worker()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_workers"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_workers'><code>crew.cluster::crew_class_launcher_cluster$launch_workers()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -91,7 +90,7 @@ Validate the launcher.
 \subsection{Method \code{script()}}{
 Generate the job script.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_pbs$script(name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_pbs$script(name, n)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -99,6 +98,10 @@ Generate the job script.
 \describe{
 \item{\code{name}}{Character of length 1, name of the job. For inspection
 purposes, you can supply a mock job name.}
+
+\item{\code{n}}{Positive integer of length 1, number of crew workers
+(i.e. cluster jobs) to launch in the current round
+of auto-scaling.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/crew_class_launcher_sge.Rd
+++ b/man/crew_class_launcher_sge.Rd
@@ -60,17 +60,16 @@ Other sge:
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="call"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-call'><code>crew::crew_class_launcher$call()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="crashes"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-crashes'><code>crew::crew_class_launcher$crashes()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch'><code>crew::crew_class_launcher$launch()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch_worker"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch_worker'><code>crew::crew_class_launcher$launch_worker()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="poll"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-poll'><code>crew::crew_class_launcher$poll()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="resolve"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-resolve'><code>crew::crew_class_launcher$resolve()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="scale"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-scale'><code>crew::crew_class_launcher$scale()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="set_name"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-set_name'><code>crew::crew_class_launcher$set_name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="settings"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-settings'><code>crew::crew_class_launcher$settings()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="start"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-start'><code>crew::crew_class_launcher$start()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate'><code>crew::crew_class_launcher$terminate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate_workers"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate_workers'><code>crew::crew_class_launcher$terminate_workers()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="update"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-update'><code>crew::crew_class_launcher$update()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="initialize"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-initialize'><code>crew.cluster::crew_class_launcher_cluster$initialize()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_worker"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_worker'><code>crew.cluster::crew_class_launcher_cluster$launch_worker()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_workers"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_workers'><code>crew.cluster::crew_class_launcher_cluster$launch_workers()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -93,7 +92,7 @@ Validate the launcher.
 \subsection{Method \code{script()}}{
 Generate the job script.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_sge$script(name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_sge$script(name, n)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -101,6 +100,10 @@ Generate the job script.
 \describe{
 \item{\code{name}}{Character of length 1, name of the job. For inspection
 purposes, you can supply a mock job name.}
+
+\item{\code{n}}{Positive integer of length 1, number of crew workers
+(i.e. cluster jobs) to launch in the current round
+of auto-scaling.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/crew_class_launcher_slurm.Rd
+++ b/man/crew_class_launcher_slurm.Rd
@@ -61,17 +61,16 @@ Other slurm:
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="call"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-call'><code>crew::crew_class_launcher$call()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="crashes"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-crashes'><code>crew::crew_class_launcher$crashes()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch'><code>crew::crew_class_launcher$launch()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="launch_worker"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-launch_worker'><code>crew::crew_class_launcher$launch_worker()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="poll"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-poll'><code>crew::crew_class_launcher$poll()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="resolve"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-resolve'><code>crew::crew_class_launcher$resolve()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="scale"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-scale'><code>crew::crew_class_launcher$scale()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="set_name"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-set_name'><code>crew::crew_class_launcher$set_name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="settings"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-settings'><code>crew::crew_class_launcher$settings()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="start"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-start'><code>crew::crew_class_launcher$start()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate'><code>crew::crew_class_launcher$terminate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="terminate_workers"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-terminate_workers'><code>crew::crew_class_launcher$terminate_workers()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew" data-topic="crew_class_launcher" data-id="update"><a href='../../crew/html/crew_class_launcher.html#method-crew_class_launcher-update'><code>crew::crew_class_launcher$update()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="initialize"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-initialize'><code>crew.cluster::crew_class_launcher_cluster$initialize()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_worker"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_worker'><code>crew.cluster::crew_class_launcher_cluster$launch_worker()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="crew.cluster" data-topic="crew_class_launcher_cluster" data-id="launch_workers"><a href='../../crew.cluster/html/crew_class_launcher_cluster.html#method-crew_class_launcher_cluster-launch_workers'><code>crew.cluster::crew_class_launcher_cluster$launch_workers()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -94,7 +93,7 @@ Validate the launcher.
 \subsection{Method \code{script()}}{
 Generate the job script.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_slurm$script(name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{crew_class_launcher_slurm$script(name, n)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -102,6 +101,10 @@ Generate the job script.
 \describe{
 \item{\code{name}}{Character of length 1, name of the job. For inspection
 purposes, you can supply a mock job name.}
+
+\item{\code{n}}{Positive integer of length 1, number of crew workers
+(i.e. cluster jobs) to launch in the current round
+of auto-scaling.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/sge/monitor.R
+++ b/tests/sge/monitor.R
@@ -12,7 +12,7 @@ test_that("SGE monitor terminate one job at a time", {
   controller$start()
   controller$launch(n = 2L)
   names <- vapply(
-    controller$launcher$instances$handle,
+    controller$launcher$launches$handle,
     function(handle) handle$name,
     FUN.VALUE = character(1L)
   )
@@ -29,7 +29,7 @@ test_that("SGE monitor terminate one job at a time", {
   expect_true(is.character(jobs$job_number))
   expect_false(anyNA(jobs$job_number))
   expect_true(all(nzchar(jobs$job_number)))
-  monitor$terminate(jobs = jobs$job_number)
+  monitor$terminate(jobs = unique(jobs$job_number))
   crew::crew_retry(
     ~ !any(jobs$job_number %in% monitor$jobs()$job_number),
     seconds_interval = 1,
@@ -53,7 +53,7 @@ test_that("THIS TEST DELETES ALL USER JOBS! USE WITH CAUTION!", {
   controller$start()
   controller$launch(n = 2L)
   names <- vapply(
-    controller$launcher$instances$handle,
+    controller$launcher$launches$handle,
     function(handle) handle$name,
     FUN.VALUE = character(1L)
   )

--- a/tests/slurm/monitor.R
+++ b/tests/slurm/monitor.R
@@ -12,7 +12,7 @@ test_that("SLURM monitor terminate one job at a time", {
   controller$start()
   controller$launch(n = 2L)
   names <- vapply(
-    controller$launcher$instances$handle,
+    controller$launcher$launches$handle,
     function(handle) handle$name,
     FUN.VALUE = character(1L)
   )
@@ -29,7 +29,7 @@ test_that("SLURM monitor terminate one job at a time", {
   expect_true(is.character(jobs$job_id))
   expect_false(anyNA(jobs$job_id))
   expect_true(all(nzchar(jobs$job_id)))
-  monitor$terminate(jobs = jobs$job_id)
+  monitor$terminate(jobs = unique(jobs$job_id))
   crew::crew_retry(
     ~ !any(jobs$job_id %in% monitor$jobs()$job_id),
     seconds_interval = 1,
@@ -53,7 +53,7 @@ test_that("THIS TEST DELETES ALL USER JOBS! USE WITH CAUTION!", {
   controller$start()
   controller$launch(n = 2L)
   names <- vapply(
-    controller$launcher$instances$handle,
+    controller$launcher$launches$handle,
     function(handle) handle$name,
     FUN.VALUE = character(1L)
   )

--- a/tests/testthat/test-crew_controller_lsf.R
+++ b/tests/testthat/test-crew_controller_lsf.R
@@ -4,12 +4,12 @@ test_that("crew_controller_lsf() script() nearly empty", {
   )
   lines <- c(
     "#!/bin/sh",
-    "#BSUB -J name",
+    "#BSUB -J \"name[1-3]\"",
     "#BSUB -cwd /home",
     "#BSUB -o /dev/null",
     "#BSUB -e /dev/null"
   )
-  expect_equal(x$launcher$script(name = "name"), lines)
+  expect_equal(x$launcher$script(name = "name", n = 3L), lines)
 })
 
 test_that("crew_controller_lsf() script() all lines", {
@@ -24,10 +24,10 @@ test_that("crew_controller_lsf() script() all lines", {
       cores = 2
     )
   )
-  out <- x$launcher$script(name = "my_name")
+  out <- x$launcher$script(name = "my_name", n = 4L)
   exp <- c(
     "#!/bin/sh",
-    "#BSUB -J my_name",
+    "#BSUB -J \"my_name[1-4]\"",
     "#BSUB -cwd /home",
     "#BSUB -o log1",
     "#BSUB -e log2",

--- a/tests/testthat/test-crew_controller_pbs.R
+++ b/tests/testthat/test-crew_controller_pbs.R
@@ -11,9 +11,10 @@ test_that("crew_controller_pbs() script() all lines", {
       walltime_hours = 57
     )
   )
-  out <- x$launcher$script(name = "this_job")
+  out <- x$launcher$script(name = "this_job", n = 4L)
   exp <- c(
     "#PBS -N this_job",
+    "#PBS -J 1-4",
     "#PBS -o out_dir/",
     "#PBS -e err_dir/",
     "#PBS -j n",

--- a/tests/testthat/test-crew_controller_sge.R
+++ b/tests/testthat/test-crew_controller_sge.R
@@ -13,9 +13,10 @@ test_that("crew_controller_sge() script() all lines", {
       gpu = 1L
     )
   )
-  out <- x$launcher$script(name = "a_job")
+  out <- x$launcher$script(name = "a_job", n = 8L)
   exp <- c(
     "#$ -N a_job",
+    "#$ -t 1-8",
     "#$ -cwd",
     "#$ -V",
     "#$ -o out_dir/",

--- a/tests/testthat/test-crew_controller_slurm.R
+++ b/tests/testthat/test-crew_controller_slurm.R
@@ -3,11 +3,12 @@ test_that("crew_controller_slurm() script() nearly empty", {
   lines <- c(
     "#!/bin/sh",
     "#SBATCH --job-name=name",
+    "#SBATCH --array=1-4",
     "#SBATCH --output=/dev/null",
     "#SBATCH --error=/dev/null",
     "#SBATCH --ntasks=1"
   )
-  expect_equal(x$launcher$script(name = "name"), lines)
+  expect_equal(x$launcher$script(name = "name", n = 4L), lines)
 })
 
 test_that("crew_controller_slurm() script() without --ntasks", {
@@ -17,10 +18,11 @@ test_that("crew_controller_slurm() script() without --ntasks", {
   lines <- c(
     "#!/bin/sh",
     "#SBATCH --job-name=name",
+    "#SBATCH --array=1-4",
     "#SBATCH --output=/dev/null",
     "#SBATCH --error=/dev/null"
   )
-  expect_equal(x$launcher$script(name = "name"), lines)
+  expect_equal(x$launcher$script(name = "name", n = 4L), lines)
 })
 
 test_that("crew_controller_slurm() script() all lines", {
@@ -36,10 +38,11 @@ test_that("crew_controller_slurm() script() all lines", {
       n_tasks = 3
     )
   )
-  out <- x$launcher$script(name = "my_name")
+  out <- x$launcher$script(name = "my_name", n = 8L)
   exp <- c(
     "#!/bin/sh",
     "#SBATCH --job-name=my_name",
+    "#SBATCH --array=1-8",
     "#SBATCH --output=log1",
     "#SBATCH --error=log2",
     "#SBATCH --mem=5192M",

--- a/tests/testthat/test-crew_launcher_cluster.R
+++ b/tests/testthat/test-crew_launcher_cluster.R
@@ -35,17 +35,13 @@ test_that("SGE subclass mock job creates a tempdir() job script", {
     )
   )
   x$start(url = "my_url", profile = "my_profile")
-  handle <- x$launch_worker(
-    call = x$call(worker = "worker_name"),
-    name = "my_name"
-  )
-  script <- file.path(tempdir(), "my_name.sh")
-  expect_equal(handle$name, "my_name")
-  expect_equal(handle$script, script)
-  expect_true(file.exists(script))
-  out <- readLines(script)
+  handle <- x$launch_workers(call = x$call(), n = 4L)
+  expect_true(is.character(handle$script) && length(handle$script) == 1L)
+  expect_false(anyNA(handle$script))
+  expect_true(file.exists(handle$script))
+  out <- readLines(handle$script)
   exp <- c(
-    "#$ -N my_name",
+    "#$ -t 1-4",
     "#$ -cwd",
     "#$ -V",
     "#$ -o out_dir/",
@@ -58,7 +54,7 @@ test_that("SGE subclass mock job creates a tempdir() job script", {
     "module load R",
     "echo 'start'"
   )
-  expect_equal(out[seq_along(exp)], exp)
+  expect_equal(out[seq_along(exp) + 1], exp)
 })
 
 test_that("SGE subclass mock job creates a custom job script", {
@@ -84,17 +80,14 @@ test_that("SGE subclass mock job creates a custom job script", {
   )
   private <- crew_private(x)
   x$start(url = "my_url", profile = "my_profile")
-  handle <- x$launch_worker(
-    call = x$call(worker = "my_worker"),
-    name = "my_name"
-  )
-  script <- file.path(dir, "my_name.sh")
-  expect_equal(handle$name, "my_name")
-  expect_equal(handle$script, script)
-  expect_true(file.exists(script))
-  out <- readLines(script)
+  handle <- x$launch_workers(call = x$call(), n = 8L)
+  expect_true(is.character(handle$script) && length(handle$script) == 1L)
+  expect_false(anyNA(handle$script))
+  expect_true(file.exists(handle$script))
+  expect_true(file.exists(handle$script))
+  out <- readLines(handle$script)
   exp <- c(
-    "#$ -N my_name",
+    "#$ -t 1-8",
     "#$ -cwd",
     "#$ -V",
     "#$ -o out_dir/",
@@ -107,5 +100,5 @@ test_that("SGE subclass mock job creates a custom job script", {
     "module load R",
     "echo 'start'"
   )
-  expect_equal(out[seq_along(exp)], exp)
+  expect_equal(out[seq_along(exp) + 1L], exp)
 })

--- a/tests/testthat/test-crew_launcher_lsf.R
+++ b/tests/testthat/test-crew_launcher_lsf.R
@@ -31,12 +31,12 @@ test_that("crew_launcher_lsf() script() nearly empty", {
   )
   lines <- c(
     "#!/bin/sh",
-    "#BSUB -J a_job",
+    "#BSUB -J \"a_job[1-8]\"",
     "#BSUB -cwd /home",
     "#BSUB -o /dev/null",
     "#BSUB -e /dev/null"
   )
-  expect_equal(x$script(name = "a_job"), lines)
+  expect_equal(x$script(name = "a_job", n = 8L), lines)
 })
 
 test_that("crew_launcher_lsf() script() all lines", {
@@ -51,10 +51,10 @@ test_that("crew_launcher_lsf() script() all lines", {
       cores = 2
     )
   )
-  out <- x$script(name = "this_job")
+  out <- x$script(name = "this_job", n = 8L)
   exp <- c(
     "#!/bin/sh",
-    "#BSUB -J this_job",
+    "#BSUB -J \"this_job[1-8]\"",
     "#BSUB -cwd /home",
     "#BSUB -o log1",
     "#BSUB -e log2",

--- a/tests/testthat/test-crew_launcher_pbs.R
+++ b/tests/testthat/test-crew_launcher_pbs.R
@@ -35,8 +35,8 @@ test_that("crew_launcher_pbs() script() nearly empty", {
     )
   )
   expect_equal(
-    x$script(name = "my_job"),
-    c("#PBS -N my_job", "#PBS -o log_file", "#PBS -j n")
+    x$script(name = "my_job", n = 10L),
+    c("#PBS -N my_job", "#PBS -J 1-10", "#PBS -o log_file", "#PBS -j n")
   )
 })
 
@@ -52,9 +52,10 @@ test_that("crew_launcher_pbs() script() all lines", {
       walltime_hours = 57
     )
   )
-  out <- x$script(name = "this_job")
+  out <- x$script(name = "this_job", n = 5L)
   exp <- c(
     "#PBS -N this_job",
+    "#PBS -J 1-5",
     "#PBS -o out_dir/",
     "#PBS -e err_dir/",
     "#PBS -j n",

--- a/tests/testthat/test-crew_launcher_sge.R
+++ b/tests/testthat/test-crew_launcher_sge.R
@@ -38,8 +38,8 @@ test_that("crew_launcher_sge() script() nearly empty", {
     )
   )
   expect_equal(
-    x$script(name = "my_job"),
-    c("#$ -N my_job", "#$ -o log_file", "#$ -j n")
+    x$script(name = "my_job", n = 2L),
+    c("#$ -N my_job", "#$ -t 1-2", "#$ -o log_file", "#$ -j n")
   )
 })
 
@@ -58,9 +58,10 @@ test_that("crew_launcher_sge() script() all lines", {
       gpu = 1L
     )
   )
-  out <- x$script(name = "this_job")
+  out <- x$script(name = "this_job", n = 4L)
   exp <- c(
     "#$ -N this_job",
+    "#$ -t 1-4",
     "#$ -cwd",
     "#$ -V",
     "#$ -o out_dir/",

--- a/tests/testthat/test-crew_launcher_slurm.R
+++ b/tests/testthat/test-crew_launcher_slurm.R
@@ -30,11 +30,12 @@ test_that("crew_launcher_slurm() script() nearly empty", {
   lines <- c(
     "#!/bin/sh",
     "#SBATCH --job-name=a_job",
+    "#SBATCH --array=1-7",
     "#SBATCH --output=/dev/null",
     "#SBATCH --error=/dev/null",
     "#SBATCH --ntasks=1"
   )
-  expect_equal(x$script(name = "a_job"), lines)
+  expect_equal(x$script(name = "a_job", n = 7L), lines)
 })
 
 test_that("crew_launcher_slurm() script() all lines", {
@@ -49,10 +50,11 @@ test_that("crew_launcher_slurm() script() all lines", {
       time_minutes = 57
     )
   )
-  out <- x$script(name = "this_job")
+  out <- x$script(name = "this_job", n = 9L)
   exp <- c(
     "#!/bin/sh",
     "#SBATCH --job-name=this_job",
+    "#SBATCH --array=1-9",
     "#SBATCH --output=log1",
     "#SBATCH --error=log2",
     "#SBATCH --mem=4198M",


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew.cluster/blob/main/CODE_OF_CONDUCT.md).
* [x] I have already submitted a [discussion topic](https://github.com/wlandau/crew.cluster/discussions) or [issue](https://github.com/wlandau/crew.cluster/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #56, #57

# Summary

This PR uses the `launch_workers()` (plural) job method instead of `launch_workers()` (singular) to support job arrays. The former is introduced in https://github.com/wlandau/crew/pull/241 and allows multiple workers to be submitted from the same system call.

For each type of cluster, this PR introduces the following line in each job script, where n is the number of workers to launch:

cluster | line
---|---
LSF | `#BSUB -J "name[1-n]"`
PBS | `#PBS -J 1-n`
SGE | `#$ -t 1-n`
SLURM | `#SBATCH --array=1-n`